### PR TITLE
feat: Adding shellcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,8 @@ RUN apt-get update -qq && apt-get install -qq -y \
     unzip \
     ca-certificates \
     python \
-    python-pip
+    python-pip \
+    shellcheck
 
 # Install Terraform.
 RUN wget -q https://releases.hashicorp.com/terraform/0.12.18/terraform_0.12.18_linux_amd64.zip

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN install terraform /usr/local/bin
 RUN terraform -v
 
 # Install tflint.
-RUN wget -q https://github.com/wata727/tflint/releases/download/v0.10.1/tflint_linux_amd64.zip
+RUN wget -q https://github.com/wata727/tflint/releases/download/v0.13.4/tflint_linux_amd64.zip
 RUN unzip tflint_linux_amd64.zip
 RUN install tflint /usr/local/bin
 RUN chmod ugo+x /usr/local/bin/tflint

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,8 @@ RUN apt-get update -qq && apt-get install -qq -y \
     shellcheck
 
 # Install Terraform.
-RUN wget -q https://releases.hashicorp.com/terraform/0.12.18/terraform_0.12.18_linux_amd64.zip
-RUN unzip terraform_0.12.18_linux_amd64.zip
+RUN wget -q https://releases.hashicorp.com/terraform/0.12.19/terraform_0.12.19_linux_amd64.zip
+RUN unzip terraform_0.12.19_linux_amd64.zip
 RUN install terraform /usr/local/bin
 RUN terraform -v
 

--- a/test.sh
+++ b/test.sh
@@ -35,6 +35,6 @@ function assert_version {
 }
 
 # Assert the versions of tools we need.
-assert_version "terraform" "terraform -v" "0.12.18"
+assert_version "terraform" "terraform -v" "0.12.19"
 assert_version "tflint" "tflint -v" "0.10.1"
 assert_version "awscli" "aws --version" "1.16"

--- a/test.sh
+++ b/test.sh
@@ -36,5 +36,5 @@ function assert_version {
 
 # Assert the versions of tools we need.
 assert_version "terraform" "terraform -v" "0.12.19"
-assert_version "tflint" "tflint -v" "0.10.1"
+assert_version "tflint" "tflint -v" "0.13.4"
 assert_version "awscli" "aws --version" "1.16"


### PR DESCRIPTION
Shellcheck is a lightweight package that allows us to do linting on bash scripts. This
allows us to use the same docker image rather than the circleci/orb which has some issues
with the git client (extremely slow).

Figured given the size of the package it wouldn't be an issue adding it into this package, hope thats okay!